### PR TITLE
Dag creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 dist/
+=======
+go.sum
+>>>>>>> dag_repo/main

--- a/dag/adder/adder.go
+++ b/dag/adder/adder.go
@@ -1,0 +1,387 @@
+package adder
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	gopath "path"
+	"sync"
+
+	chunker "github.com/ipfs/boxo/chunker"
+	"github.com/ipfs/boxo/ipld/unixfs"
+	mfs "github.com/ipfs/boxo/mfs"
+	cid "github.com/ipfs/go-cid"
+	balanced "github.com/ipfs/boxo/ipld/unixfs/importer/balanced"
+	ihelper"github.com/ipfs/boxo/ipld/unixfs/importer/helpers"
+	filestoreposinfo "github.com/ipfs/boxo/filestore/posinfo"
+	ipld "github.com/ipfs/go-ipld-format"
+	dag "github.com/ipfs/boxo/ipld/merkledag" 
+	w3fs "github.com/goddhi/storacha-go/dag/fs"
+)
+
+const (
+	DefaultChunkSize = "size-1048576" // 1MB chunks
+	
+	MaxLinks = 1048576
+	
+	UseRawLeaves = true
+	
+	LiveCacheSize = uint64(256 << 10) // 256KB
+)
+
+var (
+	DefaultCidBuilder = dag.V1CidPrefix()
+	
+	ErrNilDAGService = errors.New("DAG service cannot be nil")
+	
+	ErrInvalidFile = errors.New("invalid file")
+	
+	ErrDirectoryNotReadable = errors.New("directory not readable")
+)
+
+type Adder struct {
+	ctx        context.Context
+	dagService ipld.DAGService
+	mroot      *mfs.Root
+	liveNodes  uint64
+	mu         sync.Mutex 
+	cidBuilder cid.Builder
+	options    AdderOptions
+}
+
+type AdderOptions struct {
+	ChunkSize    string
+	MaxLinks     int
+	RawLeaves    bool
+	CidBuilder   cid.Builder
+	LiveCacheSize uint64
+}
+
+func DefaultAdderOptions() AdderOptions {
+	return AdderOptions{
+		ChunkSize:     DefaultChunkSize,
+		MaxLinks:      MaxLinks,
+		RawLeaves:     UseRawLeaves,
+		CidBuilder:    DefaultCidBuilder,
+		LiveCacheSize: LiveCacheSize,
+	}
+}
+
+
+func CreateNewAdder(ctx context.Context, dagService ipld.DAGService, opts ...func(*AdderOptions)) (*Adder, error) {
+	if dagService == nil {
+		return nil, ErrNilDAGService
+	}
+	
+	options := DefaultAdderOptions()
+	
+	for _, opt := range opts {
+		opt(&options)
+	}
+	
+	return &Adder{
+		ctx:        ctx,
+		dagService: dagService,
+		options:    options,
+		cidBuilder: options.CidBuilder,
+	}, nil
+}
+
+func WithChunkSize(size string) func(*AdderOptions) {
+	return func(o *AdderOptions) {
+		o.ChunkSize = size
+	}
+}
+
+func WithMaxLinks(maxLinks int) func(*AdderOptions) {
+	return func(o *AdderOptions) {
+		o.MaxLinks = maxLinks
+	}
+}
+
+func WithRawLeaves(rawLeaves bool) func(*AdderOptions) {
+	return func(o *AdderOptions) {
+		o.RawLeaves = rawLeaves
+	}
+}
+
+func WithCidBuilder(builder cid.Builder) func(*AdderOptions) {
+	return func(o *AdderOptions) {
+		o.CidBuilder = builder
+	}
+}
+
+func WithLiveCacheSize(size uint64) func(*AdderOptions) {
+	return func(o *AdderOptions) {
+		o.LiveCacheSize = size
+	}
+}
+
+
+func (adder *Adder) Add(file fs.File, dirname string, fsys fs.FS) (cid.Cid, error) {
+	if file == nil {
+		return cid.Undef, ErrInvalidFile
+	}
+	
+	if fsys == nil {
+		fsys = &w3fs.OsFs{} 
+	}
+
+	fileStat, err := file.Stat()
+	if err != nil {
+		return cid.Undef, fmt.Errorf("stat file: %w", err)
+	}
+
+	nd, err := adder.addAll(file, fileStat, dirname, fsys)
+	if err != nil {
+		return cid.Undef, fmt.Errorf("add all: %w", err)
+	}
+	
+	return nd.Cid(), nil
+}
+
+func (adder *Adder) MfsRoot() (*mfs.Root, error) {
+	adder.mu.Lock()
+	defer adder.mu.Unlock()
+	
+	if adder.mroot != nil {
+		return adder.mroot, nil
+	}
+	
+	rnode := unixfs.EmptyDirNode()
+	rnode.SetCidBuilder(adder.cidBuilder)
+	
+	mr, err := mfs.NewRoot(adder.ctx, adder.dagService, rnode, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create MFS root: %w", err)
+	}
+	
+	adder.mroot = mr
+	return adder.mroot, nil
+}
+
+
+func (adder *Adder) add(reader io.Reader) (ipld.Node, error) {
+	chunker, err := chunker.FromString(reader, adder.options.ChunkSize)
+	if err != nil {
+		return nil, fmt.Errorf("create chunker: %w", err)
+	}
+
+	params := ihelper.DagBuilderParams{
+		Dagserv:    adder.dagService,
+		RawLeaves:  adder.options.RawLeaves,
+		Maxlinks:   adder.options.MaxLinks,
+		CidBuilder: adder.cidBuilder,
+	}
+
+	db, err := params.New(chunker)
+	if err != nil {
+		return nil, fmt.Errorf("create DAG builder: %w", err)
+	}
+
+	node, err := balanced.Layout(db)
+	if err != nil {
+		return nil, fmt.Errorf("build balanced layout: %w", err)
+	}
+
+	return node, nil
+}
+
+func (adder *Adder) addNode(node ipld.Node, path string) error {
+	if path == "" {
+		path = node.Cid().String()
+	}
+	
+	if pi, ok := node.(*filestoreposinfo.FilestoreNode); ok {
+		node = pi.Node
+	}
+
+	mr, err := adder.MfsRoot()
+	if err != nil {
+		return err
+	}
+
+	dir := gopath.Dir(path)
+	if dir != "." {
+		opts := mfs.MkdirOpts{
+			Mkparents:  true,
+			Flush:      false,
+			CidBuilder: adder.cidBuilder,
+		}
+		
+		if err := mfs.Mkdir(mr, dir, opts); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+	}
+
+	if err := mfs.PutNode(mr, path, node); err != nil {
+		return fmt.Errorf("put node at %s: %w", path, err)
+	}
+
+	_, err = mfs.NewFile(path, node, nil, adder.dagService)
+	if err != nil {
+		return fmt.Errorf("create MFS file at %s: %w", path, err)
+	}
+	
+	return nil
+}
+
+
+func (adder *Adder) addAll(f fs.File, fi fs.FileInfo, dirname string, fsys fs.FS) (ipld.Node, error) {
+	if err := adder.addFileOrDir(fi.Name(), f, fi, dirname, fsys, true); err != nil {
+		return nil, fmt.Errorf("add file or directory: %w", err)
+	}
+
+	mr, err := adder.MfsRoot()
+	if err != nil {
+		return nil, fmt.Errorf("get MFS root: %w", err)
+	}
+
+	rootdir := mr.GetDirectory()
+	
+	if err = rootdir.Flush(); err != nil {
+		return nil, fmt.Errorf("flush root directory: %w", err)
+	}
+
+	if err = mr.Close(); err != nil {
+		return nil, fmt.Errorf("close MFS root: %w", err)
+	}
+
+	nd, err := rootdir.GetNode()
+	if err != nil {
+		return nil, fmt.Errorf("get root node: %w", err)
+	}
+
+	if err = adder.dagService.Add(adder.ctx, nd); err != nil {
+		return nil, fmt.Errorf("add root node to DAG service: %w", err)
+	}
+
+	return nd, nil
+}
+
+func (adder *Adder) addFileOrDir(path string, f fs.File, fi fs.FileInfo, dirname string, fsys fs.FS, toplevel bool) error {
+	defer f.Close()
+	
+	adder.mu.Lock()
+	needsFlush := adder.liveNodes >= adder.options.LiveCacheSize
+	adder.liveNodes++
+	adder.mu.Unlock()
+	
+	if needsFlush {
+		mr, err := adder.MfsRoot()
+		if err != nil {
+			return err
+		}
+		
+		if err := mr.FlushMemFree(adder.ctx); err != nil {
+			return fmt.Errorf("flush memory: %w", err)
+		}
+		
+		adder.mu.Lock()
+		adder.liveNodes = 0
+		adder.mu.Unlock()
+	}
+
+	if fi.IsDir() {
+		return adder.addDir(path, f, dirname, fsys, toplevel)
+	}
+	
+	return adder.addFile(path, f)
+}
+
+func (adder *Adder) addFile(path string, f fs.File) error {
+	dagnode, err := adder.add(f)
+	if err != nil {
+		return fmt.Errorf("add file content: %w", err)
+	}
+	
+	return adder.addNode(dagnode, path)
+}
+
+func (adder *Adder) addDir(path string, dir fs.File, dirname string, fsys fs.FS, toplevel bool) error {
+	if !(toplevel && path == "") {
+		mr, err := adder.MfsRoot()
+		if err != nil {
+			return err
+		}
+		
+		err = mfs.Mkdir(mr, path, mfs.MkdirOpts{
+			Mkparents:  true,
+			Flush:      false,
+			CidBuilder: adder.cidBuilder,
+		})
+		
+		if err != nil {
+			return fmt.Errorf("mkdir %s: %w", path, err)
+		}
+	}
+
+	var ents []fs.DirEntry
+	var err error
+	
+	switch {
+	case dir != nil:
+		if d, ok := dir.(fs.ReadDirFile); ok {
+			ents, err = d.ReadDir(0)
+		}
+	case fsys != nil:
+		if dfsys, ok := fsys.(fs.ReadDirFS); ok {
+			ents, err = dfsys.ReadDir(gopath.Join(dirname, path))
+		}
+	default:
+		return ErrDirectoryNotReadable
+	}
+	
+	if err != nil {
+		return fmt.Errorf("reading directory %s: %w", gopath.Join(dirname, path), err)
+	}
+	
+	if ents == nil {
+		return fmt.Errorf("%w: %s", ErrDirectoryNotReadable, gopath.Join(dirname, path))
+	}
+
+	for _, ent := range ents {
+		var f fs.File
+		
+		if ef, ok := ent.(w3fs.Opener); ok {
+			f, err = ef.Open()
+		} else {
+			f, err = fsys.Open(gopath.Join(dirname, path, ent.Name()))
+		}
+		
+		if err != nil {
+			return fmt.Errorf("opening file %s: %w", gopath.Join(dirname, path, ent.Name()), err)
+		}
+
+		fi, err := ent.Info()
+		if err != nil {
+			f.Close() 
+			return fmt.Errorf("get file info for %s: %w", ent.Name(), err)
+		}
+
+		entryPath := gopath.Join(path, ent.Name())
+		if err = adder.addFileOrDir(entryPath, f, fi, dirname, fsys, false); err != nil {
+			return fmt.Errorf("add entry %s: %w", entryPath, err)
+		}
+	}
+	
+	return nil
+}
+
+func (adder *Adder) Close() error {
+	adder.mu.Lock()
+	defer adder.mu.Unlock()
+	
+	if adder.mroot != nil {
+		if err := adder.mroot.Close(); err != nil {
+			return fmt.Errorf("close MFS root: %w", err)
+		}
+		adder.mroot = nil
+	}
+	
+	return nil
+}
+
+

--- a/dag/adder/adder_test.go
+++ b/dag/adder/adder_test.go
@@ -1,0 +1,157 @@
+package adder
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	blockstore "github.com/ipfs/boxo/blockstore"
+	blockservice "github.com/ipfs/go-blockservice"
+	ds "github.com/ipfs/go-datastore"
+	dsync "github.com/ipfs/go-datastore/sync"
+	ipld "github.com/ipfs/go-ipld-format"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
+)
+
+func TestDefaultAdderOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		want AdderOptions
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DefaultAdderOptions(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DefaultAdderOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func createTestDagService() ipld.DAGService {
+	dstore := dsync.MutexWrap(ds.NewMapDatastore())
+	bstore := blockstore.NewBlockstore(dstore)
+	bservice := blockservice.New(bstore, nil)
+	return dag.NewDAGService(bservice)
+}
+
+func TestCreateNewAdder(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		dagService ipld.DAGService
+		opts       []func(*AdderOptions)
+		want       *Adder
+		wantErr    bool
+		errMsg     string
+	}{
+		{
+			name:       "nil DAG service returns error",
+			ctx:        context.Background(),
+			dagService: nil,
+			opts:       nil,
+			want:       nil,
+			wantErr:    true,
+			errMsg:     ErrNilDAGService.Error(),
+		},
+		{
+			name:       "default options",
+			ctx:        context.Background(),
+			dagService: createTestDagService(),
+			opts:       nil,
+			want: &Adder{
+				ctx:        context.Background(),
+				dagService: createTestDagService(),
+				options:    DefaultAdderOptions(),
+				cidBuilder: DefaultCidBuilder,
+			},
+			wantErr: false,
+		},
+		{
+			name:       "with custom chunk size",
+			ctx:        context.Background(),
+			dagService: createTestDagService(),
+			opts:       []func(*AdderOptions){WithChunkSize("size-262144")},
+			want: &Adder{
+				ctx:        context.Background(),
+				dagService: createTestDagService(),
+				options: AdderOptions{
+					ChunkSize:     "size-262144",
+					MaxLinks:      MaxLinks,
+					RawLeaves:     UseRawLeaves,
+					CidBuilder:    DefaultCidBuilder,
+					LiveCacheSize: LiveCacheSize,
+				},
+				cidBuilder: DefaultCidBuilder,
+			},
+			wantErr: false,
+		},
+		{
+			name:       "with multiple options",
+			ctx:        context.Background(),
+			dagService: createTestDagService(),
+			opts: []func(*AdderOptions){
+				WithChunkSize("size-262144"),
+				WithMaxLinks(500),
+				WithRawLeaves(false),
+				WithLiveCacheSize(1024),
+			},
+			want: &Adder{
+				ctx:        context.Background(),
+				dagService: createTestDagService(),
+				options: AdderOptions{
+					ChunkSize:     "size-262144",
+					MaxLinks:      500,
+					RawLeaves:     false,
+					CidBuilder:    DefaultCidBuilder,
+					LiveCacheSize: 1024,
+				},
+				cidBuilder: DefaultCidBuilder,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateNewAdder(tt.ctx, tt.dagService, tt.opts...)
+
+			// Check error cases
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateNewAdder() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && err.Error() != tt.errMsg {
+				t.Errorf("CreateNewAdder() error = %v, want error %v", err, tt.errMsg)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			// For non-error cases, check fields individually since we can't directly compare DAGService
+			if got.ctx != tt.want.ctx {
+				t.Errorf("CreateNewAdder() ctx = %v, want %v", got.ctx, tt.want.ctx)
+			}
+
+			if got.options.ChunkSize != tt.want.options.ChunkSize {
+				t.Errorf("CreateNewAdder() ChunkSize = %v, want %v", got.options.ChunkSize, tt.want.options.ChunkSize)
+			}
+
+			if got.options.MaxLinks != tt.want.options.MaxLinks {
+				t.Errorf("CreateNewAdder() MaxLinks = %v, want %v", got.options.MaxLinks, tt.want.options.MaxLinks)
+			}
+
+			if got.options.RawLeaves != tt.want.options.RawLeaves {
+				t.Errorf("CreateNewAdder() RawLeaves = %v, want %v", got.options.RawLeaves, tt.want.options.RawLeaves)
+			}
+
+			if got.options.LiveCacheSize != tt.want.options.LiveCacheSize {
+				t.Errorf("CreateNewAdder() LiveCacheSize = %v, want %v", got.options.LiveCacheSize, tt.want.options.LiveCacheSize)
+			}
+		})
+	}
+}

--- a/dag/car.go
+++ b/dag/car.go
@@ -1,0 +1,86 @@
+package car
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+
+	"github.com/goddhi/storacha-go/dag/adder"
+	"github.com/ipfs/boxo/blockservice"
+	blockstore "github.com/ipfs/boxo/blockstore"
+	"github.com/ipfs/boxo/ipld/merkledag"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/sync"
+	gocar "github.com/ipld/go-car/v2"
+	carstorage "github.com/ipld/go-car/v2/storage"
+)
+
+func BuildCAR(ctx context.Context, file fs.File, path string, fsys fs.FS) (io.Reader, cid.Cid, error) {
+	ds := datastore.NewMapDatastore()
+	bs := blockstore.NewBlockstore(sync.MutexWrap(ds))
+	bserv := blockservice.New(bs, nil)
+	dagService := merkledag.NewDAGService(bserv)
+
+	add, err := adder.CreateNewAdder(ctx, dagService)
+	if err != nil {
+		return nil, cid.Undef, fmt.Errorf("creating adder: %w", err)
+	}
+	defer add.Close()
+
+	rootCid, err := add.Add(file, path, fsys)
+	if err != nil {
+		return nil, cid.Undef, fmt.Errorf("adding to DAG: %w", err)
+	}
+
+	buf := new(bytes.Buffer)
+
+	carBlockStore, err := carstorage.NewWritable(buf, []cid.Cid{rootCid}, gocar.WriteAsCarV1(true))
+	if err != nil {
+		return nil, cid.Undef, fmt.Errorf("creating CAR blockstore: %w", err)
+	}
+	defer carBlockStore.Finalize() 
+
+	seenBlocks := make(map[string]bool)
+
+	var collectBlocks func(c cid.Cid) error
+	collectBlocks = func(c cid.Cid) error {
+		if seenBlocks[c.String()] {
+			return nil
+		}
+		seenBlocks[c.String()] = true
+
+		nd, err := dagService.Get(ctx, c)
+		if err != nil {
+			return fmt.Errorf("getting node %s: %w", c, err)
+		}
+
+		blk, err := blocks.NewBlockWithCid(nd.RawData(), c)
+		if err != nil {
+			return fmt.Errorf("creating block: %w", err)
+		}
+
+		err = carBlockStore.Put(ctx, blk.Cid().String(), blk.RawData())
+		if err != nil {
+			return fmt.Errorf("writing block to CAR: %w", err)
+		}
+
+		for _, link := range nd.Links() {
+			err := collectBlocks(link.Cid)
+			if err != nil {
+				return err
+			} 
+		}
+		return nil
+	}
+
+	err = collectBlocks(rootCid)
+	if err != nil {
+		return nil, cid.Undef, fmt.Errorf("collecting blocks: %w", err)
+	}
+
+	return buf, rootCid, nil
+}

--- a/dag/fs/fs.go
+++ b/dag/fs/fs.go
@@ -1,0 +1,43 @@
+package fs
+
+import (
+	"io/fs"
+	"os"
+)
+
+type Opener interface {
+	Open() (fs.File, error)
+}
+
+type OsEntry struct {
+	Path     string
+	FileInfo fs.FileInfo
+}
+
+func (e *OsEntry) Open() (fs.File, error) {
+	return os.Open(e.Path)
+}
+
+func (e *OsEntry) Name() string {
+	return e.FileInfo.Name()
+}
+
+func (e *OsEntry) IsDir() bool {
+	return e.FileInfo.IsDir()
+}
+
+func (e *OsEntry) Type() fs.FileMode {
+	return e.FileInfo.Mode().Type()
+}
+
+func (e *OsEntry) Info() (fs.FileInfo, error) {
+	return e.FileInfo, nil
+}
+
+type OsFs struct {
+	Root string
+}
+
+func (f *OsFs) Open(name string) (fs.File, error) {
+	return os.Open(name)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 module github.com/web3-storage/go-w3up
 
 go 1.21.4
@@ -40,10 +41,56 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
+=======
+module github.com/goddhi/storacha-go
+
+go 1.23.6
+
+require (
+	github.com/ipfs/boxo v0.28.0
+	github.com/ipfs/go-block-format v0.2.0
+	github.com/ipfs/go-blockservice v0.5.2
+	github.com/ipfs/go-cid v0.5.0
+	github.com/ipfs/go-datastore v0.7.0
+	github.com/ipfs/go-ipld-format v0.6.0
+	github.com/ipld/go-car/v2 v2.14.2
+)
+
+require (
+	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
+	github.com/crackcomm/go-gitignore v0.0.0-20241020182519-7843d2ba8fdf // indirect
+	github.com/gammazero/deque v1.0.0 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/ipfs/bbloom v0.0.4 // indirect
+	github.com/ipfs/go-bitfield v1.1.0 // indirect
+	github.com/ipfs/go-ipfs-blockstore v1.3.1 // indirect
+	github.com/ipfs/go-ipfs-ds-help v1.1.1 // indirect
+	github.com/ipfs/go-ipfs-exchange-interface v0.2.1 // indirect
+	github.com/ipfs/go-ipfs-util v0.0.3 // indirect
+	github.com/ipfs/go-ipld-cbor v0.1.0 // indirect
+	github.com/ipfs/go-ipld-legacy v0.2.1 // indirect
+	github.com/ipfs/go-log v1.0.5 // indirect
+	github.com/ipfs/go-log/v2 v2.5.1 // indirect
+	github.com/ipfs/go-metrics-interface v0.0.1 // indirect
+	github.com/ipfs/go-verifcid v0.0.3 // indirect
+	github.com/ipld/go-codec-dagpb v1.6.0 // indirect
+	github.com/ipld/go-ipld-prime v0.21.0 // indirect
+	github.com/jbenet/goprocess v0.1.4 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
+	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/minio/sha256-simd v1.0.1 // indirect
+>>>>>>> dag_repo/main
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect
+<<<<<<< HEAD
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -60,4 +107,30 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect
+=======
+	github.com/multiformats/go-multicodec v0.9.0 // indirect
+	github.com/multiformats/go-multihash v0.2.3 // indirect
+	github.com/multiformats/go-varint v0.0.7 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 // indirect
+	github.com/polydawn/refmt v0.89.0 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 // indirect
+	github.com/whyrusleeping/cbor-gen v0.1.2 // indirect
+	github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel v1.34.0 // indirect
+	go.opentelemetry.io/otel/metric v1.34.0 // indirect
+	go.opentelemetry.io/otel/trace v1.34.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac // indirect
+	golang.org/x/sync v0.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
+	google.golang.org/protobuf v1.36.5 // indirect
+	lukechampine.com/blake3 v1.3.0 // indirect
+>>>>>>> dag_repo/main
 )

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,5 @@
+# Implementation of DAG in Golang for Storacha go-w3up
+##  Step 1 
+### Adder Package Implementation 
+The adder package provides functionality to add files and directories to content-addressed storage by chunking data, constructing a Directed Acyclic Graph (DAG), and integrating with a Mutable File System for retrieval. 
+The [go-w3s-client](https://github.com/web3-storage/go-w3s-client) provides a reference implementation for building the DAG in this repo.


### PR DESCRIPTION
Implementation of DAG in Golang for Storacha go-w3up
Adder Package Implementation
The adder package provides functionality to add files and directories to content-addressed storage by chunking data, constructing a Directed Acyclic Graph (DAG), and integrating with a Mutable File System for retrieval. The [go-w3s-client](https://github.com/web3-storage/go-w3s-client) provides a reference implementation for building the DAG in this repo.
